### PR TITLE
fix: stop committing snapshots to repo, keep only in GitHub Releases

### DIFF
--- a/.github/workflows/update-smt.yml
+++ b/.github/workflows/update-smt.yml
@@ -35,9 +35,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -f data/
-          git commit -m "update: CRL data $(date -u +%Y%m%d%H%M)"
-          git push
+          git add data/*/root.json
+          git diff --cached --quiet || git commit -m "update: CRL data $(date -u +%Y%m%d%H%M)"
+          git diff --cached --quiet || git push
 
       - name: Upload snapshot
         if: steps.build.outputs.changed == 'true'

--- a/.github/workflows/update-smt.yml
+++ b/.github/workflows/update-smt.yml
@@ -36,8 +36,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/*/root.json
-          git diff --cached --quiet || git commit -m "update: CRL data $(date -u +%Y%m%d%H%M)"
-          git diff --cached --quiet || git push
+          if ! git diff --cached --quiet; then
+            git commit -m "update: CRL data $(date -u +%Y%m%d%H%M)"
+            git push
+          fi
 
       - name: Upload snapshot
         if: steps.build.outputs.changed == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Data and snapshots
-data/
+# Snapshot binaries (kept in GitHub Releases only)
+server/data/**/*.json.gz
 
 # Go server
 server/bin/


### PR DESCRIPTION
## Summary

- **Stop committing ~76MB snapshot files** to the repo — they're already uploaded to GitHub Releases (`snapshot-latest`) and the server downloads from there as fallback
- **Update `.gitignore`** to ignore only `*.json.gz` snapshots while allowing `root.json` to be tracked normally (used by `smtbuild` to detect unchanged roots)
- **Update CI workflow** to commit only `root.json` instead of `git add -f data/`, with diff guards to avoid failures when nothing changed
- **Untrack `server/data/g2/tree-snapshot.json.gz`** from git index

## Test plan

- [ ] Verify `git check-ignore server/data/g2/tree-snapshot.json.gz` returns ignored
- [ ] Verify `git check-ignore server/data/g2/root.json` returns NOT ignored
- [ ] Verify CI workflow runs successfully on next cron trigger
- [ ] Verify snapshots are still uploaded to GitHub Releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)