### PR TITLE
feat: reduce SMT tree depth from 256 to 128

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,8 @@ Simple root registry: `setRoot(bytes32 issuerId, uint256 newRoot, uint256 crlNum
 ## SMT Implementation Details
 
 - **Hash:** Poseidon over P-256 (secq256r1) scalar field via `go-poseidon-p256`
-- **Depth:** 256 (fixed for wire compatibility)
-- **Path encoding:** LSB-first — `key.Bit(i)` for i in 0..255
+- **Depth:** 128 (sufficient for MOICA 64–128 bit serial numbers; keys exceeding depth are rejected)
+- **Path encoding:** LSB-first — `key.Bit(i)` for i in 0..127
 - **Leaf node:** `Hash3(key, value, 1)` stored as `[key, value, 1]`
 - **Branch node:** `Hash2(left, right)` stored as `[left, right]`
 - **Entry value:** Always `1` (membership marker)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Snapshots are gzip-compressed JSON containing the full SMT node tree, compatible
 
 ### `GET /proof/{issuerId}/{sn}`
 
-Returns a membership or non-membership proof. Serial number accepts hex with or without `0x` prefix (max 64 hex chars).
+Returns a membership or non-membership proof. Serial number accepts hex with or without `0x` prefix (max 32 hex chars).
 
 ```json
 {
@@ -68,13 +68,14 @@ Returns a membership or non-membership proof. Serial number accepts hex with or 
   "matchingEntry": ["0x...", "0x...", "0x1"],
   "siblings": ["0x...", "0x...", "..."],
   "root": "0x3c2151...",
-  "membership": false
+  "membership": false,
+  "depth": 128
 }
 ```
 
 - `entry` — `[key, value, 1]` for the queried serial
 - `matchingEntry` — present only for non-membership proofs
-- `siblings` — 256 sibling hashes
+- `siblings` — up to 128 sibling hashes (varies by proof)
 - All BigInt values are 0x-prefixed hex strings
 
 ### `GET /status`
@@ -151,11 +152,11 @@ Required secrets: `RPC_URL`, `RELAYER_PRIVATE_KEY`, `CONTRACT_ADDRESS`
 Wire-compatible with `@zk-kit/smt` v1.0.2 (`bigNumbers` mode):
 
 - **Hash:** Poseidon over secq256r1 scalar field via `go-poseidon-p256`
-- **Tree depth:** 256
-- **Path encoding:** LSB-first (`big.Int.Bit(i)` for i in 0..255)
+- **Tree depth:** 128 (sufficient for MOICA 64–128 bit serial numbers; halves proof size vs 256)
+- **Path encoding:** LSB-first (`big.Int.Bit(i)` for i in 0..127)
 - **Leaf node:** `Hash3(key, value, 1)` — the `1` is the entry mark
 - **Branch node:** `Hash2(left, right)`
-- **Proof:** entry `[key, value, 1]` + 256 siblings; non-membership includes optional matching entry
+- **Proof:** entry `[key, value, 1]` + up to 128 siblings; non-membership includes optional matching entry
 
 ## Data Scale
 

--- a/server/cmd/smtbuild/main.go
+++ b/server/cmd/smtbuild/main.go
@@ -69,7 +69,7 @@ func main() {
 		log.Printf("[%s] %d unique serials (removed %d duplicates)",
 			iss.ID, len(uniqueSerials), len(parsed.RevokedSerials)-len(uniqueSerials))
 
-		// Build SMT with default depth 256 for wire-compatibility
+		// Build SMT with default depth 128 (sufficient for MOICA serial numbers)
 		tree := smt.New(hasher)
 		buildStart := time.Now()
 		err = tree.BatchAddWithProgress(uniqueSerials, entryVal, 10000, func(done, total int) {

--- a/server/internal/api/grpcapi/service.go
+++ b/server/internal/api/grpcapi/service.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/moven0831/moica-revocation-smt/server/internal/manager"
+	"github.com/moven0831/moica-revocation-smt/server/internal/smt"
 	pb "github.com/moven0831/moica-revocation-smt/server/pkg/proto/revocation"
 )
 
@@ -37,7 +38,7 @@ func bigToHex(n *big.Int) string {
 
 func (s *RevocationServer) GetProof(ctx context.Context, req *pb.GetProofRequest) (*pb.GetProofResponse, error) {
 	snHex := strings.TrimPrefix(req.SerialNumber, "0x")
-	if len(snHex) == 0 || len(snHex) > 64 {
+	if len(snHex) == 0 || len(snHex) > 32 {
 		return nil, status.Error(codes.InvalidArgument, "invalid serial number")
 	}
 
@@ -61,6 +62,7 @@ func (s *RevocationServer) GetProof(ctx context.Context, req *pb.GetProofRequest
 		Siblings:     bigSliceToHex(proof.Siblings),
 		Root:         bigToHex(proof.Root),
 		Membership:   proof.Membership,
+		Depth:        int32(smt.DefaultDepth),
 	}
 	if proof.MatchingEntry != nil {
 		resp.MatchingEntry = bigSliceToHex(proof.MatchingEntry)

--- a/server/internal/api/rest/handler.go
+++ b/server/internal/api/rest/handler.go
@@ -48,6 +48,7 @@ type ProofResponse struct {
 	Siblings      []string `json:"siblings"`
 	Root          string   `json:"root"`
 	Membership    bool     `json:"membership"`
+	Depth         int      `json:"depth"`
 }
 
 // StatusResponse matches the TS API status format.
@@ -67,9 +68,9 @@ func (h *Handler) getProof(w http.ResponseWriter, r *http.Request) {
 	issuerID := chi.URLParam(r, "issuerId")
 	snHex := chi.URLParam(r, "sn")
 
-	// Validate serial number: must be hex, max 64 chars
+	// Validate serial number: must be hex, max 32 chars (128 bits)
 	snHex = strings.TrimPrefix(snHex, "0x")
-	if len(snHex) == 0 || len(snHex) > 64 {
+	if len(snHex) == 0 || len(snHex) > 32 {
 		http.Error(w, `{"error":"invalid serial number"}`, http.StatusBadRequest)
 		return
 	}
@@ -96,6 +97,7 @@ func (h *Handler) getProof(w http.ResponseWriter, r *http.Request) {
 		Siblings:     bigSliceToHex(proof.Siblings),
 		Root:         bigToHex(proof.Root),
 		Membership:   proof.Membership,
+		Depth:        smt.DefaultDepth,
 	}
 	if proof.MatchingEntry != nil {
 		resp.MatchingEntry = bigSliceToHex(proof.MatchingEntry)

--- a/server/internal/api/rest/handler_test.go
+++ b/server/internal/api/rest/handler_test.go
@@ -50,6 +50,9 @@ func TestGetProofMembership(t *testing.T) {
 	if len(resp.Entry) != 3 {
 		t.Errorf("entry length: got %d, want 3", len(resp.Entry))
 	}
+	if resp.Depth != smt.DefaultDepth {
+		t.Errorf("depth: got %d, want %d", resp.Depth, smt.DefaultDepth)
+	}
 
 	// Verify the proof
 	h := smt.NewPoseidonHasher()

--- a/server/internal/smt/path.go
+++ b/server/internal/smt/path.go
@@ -2,13 +2,15 @@ package smt
 
 import "math/big"
 
-// DefaultDepth is the standard tree depth for 256-bit keys.
-const DefaultDepth = 256
+// DefaultDepth is the standard tree depth for 128-bit keys.
+// MOICA certificate serial numbers are 64–128 bits, so 128 levels
+// are sufficient and halve proof size compared to 256.
+const DefaultDepth = 128
 
 // KeyToPath converts a key (big.Int) to a path of the given depth (LSB-first).
 // path[i] = key.Bit(i), matching the TS implementation:
 //
-//	key.toString(2).padStart(256, "0").split("").reverse().map(Number)
+//	key.toString(2).padStart(depth, "0").split("").reverse().map(Number)
 func KeyToPath(key *big.Int, depth int) []byte {
 	path := make([]byte, depth)
 	for i := 0; i < depth; i++ {

--- a/server/internal/smt/smt_test.go
+++ b/server/internal/smt/smt_test.go
@@ -381,6 +381,21 @@ func TestDeleteAllEntries(t *testing.T) {
 	}
 }
 
+func TestAddKeyExceedingDepth(t *testing.T) {
+	h := NewPoseidonHasher()
+	tree := New(h)
+
+	// A 129-bit key should be rejected at depth 128
+	bigKey := new(big.Int).Lsh(big.NewInt(1), 128) // 2^128
+	err := tree.Add(bigKey, big.NewInt(1))
+	if err == nil {
+		t.Fatal("expected error for key exceeding tree depth")
+	}
+	if tree.Count != 0 {
+		t.Errorf("count should be 0 after rejected add, got %d", tree.Count)
+	}
+}
+
 func TestDeterministicRoot(t *testing.T) {
 	h := NewPoseidonHasher()
 

--- a/server/internal/smt/tree.go
+++ b/server/internal/smt/tree.go
@@ -22,7 +22,7 @@ type SMT struct {
 	Depth int // Tree depth (number of bits in key path)
 }
 
-// New creates a new empty SMT with the given hasher and default depth (256).
+// New creates a new empty SMT with the given hasher and default depth (128).
 func New(h Hasher) *SMT {
 	return NewWithDepth(h, DefaultDepth)
 }
@@ -81,6 +81,10 @@ func (t *SMT) Add(key, value *big.Int) error {
 
 // addUnlocked is the lock-free core of Add, for use by batch methods that hold the lock.
 func (t *SMT) addUnlocked(key, value *big.Int) error {
+	if key.BitLen() > t.Depth {
+		return fmt.Errorf("key exceeds tree depth: %d bits > %d", key.BitLen(), t.Depth)
+	}
+
 	entry, matchingEntry, siblings := t.retrieveEntry(key)
 
 	if len(entry) >= 2 && entry[1] != nil {

--- a/server/pkg/proto/revocation/revocation.pb.go
+++ b/server/pkg/proto/revocation/revocation.pb.go
@@ -82,6 +82,7 @@ type GetProofResponse struct {
 	Siblings      []string               `protobuf:"bytes,5,rep,name=siblings,proto3" json:"siblings,omitempty"`
 	Root          string                 `protobuf:"bytes,6,opt,name=root,proto3" json:"root,omitempty"`
 	Membership    bool                   `protobuf:"varint,7,opt,name=membership,proto3" json:"membership,omitempty"`
+	Depth         int32                  `protobuf:"varint,8,opt,name=depth,proto3" json:"depth,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -163,6 +164,13 @@ func (x *GetProofResponse) GetMembership() bool {
 		return x.Membership
 	}
 	return false
+}
+
+func (x *GetProofResponse) GetDepth() int32 {
+	if x != nil {
+		return x.Depth
+	}
+	return 0
 }
 
 type GetStatusRequest struct {
@@ -337,7 +345,7 @@ const file_pkg_proto_revocation_revocation_proto_rawDesc = "" +
 	"revocation\"S\n" +
 	"\x0fGetProofRequest\x12\x1b\n" +
 	"\tissuer_id\x18\x01 \x01(\tR\bissuerId\x12#\n" +
-	"\rserial_number\x18\x02 \x01(\tR\fserialNumber\"\xe1\x01\n" +
+	"\rserial_number\x18\x02 \x01(\tR\fserialNumber\"\xf7\x01\n" +
 	"\x10GetProofResponse\x12\x1b\n" +
 	"\tissuer_id\x18\x01 \x01(\tR\bissuerId\x12#\n" +
 	"\rserial_number\x18\x02 \x01(\tR\fserialNumber\x12\x14\n" +
@@ -347,7 +355,8 @@ const file_pkg_proto_revocation_revocation_proto_rawDesc = "" +
 	"\x04root\x18\x06 \x01(\tR\x04root\x12\x1e\n" +
 	"\n" +
 	"membership\x18\a \x01(\bR\n" +
-	"membership\"\x12\n" +
+	"membership\x12\x14\n" +
+	"\x05depth\x18\b \x01(\x05R\x05depth\"\x12\n" +
 	"\x10GetStatusRequest\"\xe6\x01\n" +
 	"\x11GetStatusResponse\x12P\n" +
 	"\vgenerations\x18\x01 \x03(\v2..revocation.GetStatusResponse.GenerationsEntryR\vgenerations\x12%\n" +

--- a/server/pkg/proto/revocation/revocation.proto
+++ b/server/pkg/proto/revocation/revocation.proto
@@ -22,6 +22,7 @@ message GetProofResponse {
   repeated string siblings = 5;
   string root = 6;
   bool membership = 7;
+  int32 depth = 8;
 }
 
 message GetStatusRequest {}


### PR DESCRIPTION
## Summary

- Reduce `DefaultDepth` from 256 to 128 — MOICA serial numbers are 64–128 bits, so 128 levels are sufficient. This halves proof size and cuts ZK circuit constraints ~50%.
- Add key bounds check in `addUnlocked()` to reject keys exceeding tree depth
- Tighten REST/gRPC serial number validation from 64 to 32 hex chars (128 bits)
- Add `depth` field to proof responses (REST JSON + protobuf) so clients know the tree depth

**Breaking change:** All snapshots must be rebuilt. External consumers must update to expect depth 128 and the new `depth` field in proof responses.

Closes #5

## Test plan

- [x] `make test` — all unit tests pass (existing vectors unchanged since test keys are ≤128 bits)
- [x] `TestAddKeyExceedingDepth` — verifies 129-bit key is rejected
- [x] `TestGetProofMembership` — verifies depth field in REST response
- [x] `make proto && go build ./...` — proto regen and full build succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)