### PR TITLE
fix(ci): pull --rebase before push in update-smt workflow

### DIFF
--- a/.github/workflows/update-smt.yml
+++ b/.github/workflows/update-smt.yml
@@ -38,6 +38,7 @@ jobs:
           git add data/*/root.json
           if ! git diff --cached --quiet; then
             git commit -m "update: CRL data $(date -u +%Y%m%d%H%M)"
+            git pull --rebase
             git push
           fi
 


### PR DESCRIPTION
## Summary
- Add `git pull --rebase` before `git push` in the update-smt workflow's commit step
- Fixes push rejection caused by remote commits landing during the ~2h SMT build window (e.g. [run #23255521559](https://github.com/moven0831/moica-revocation-smt/actions/runs/23255521559/job/67609227303))

## Test plan
- [ ] Manually trigger `update-smt` workflow via `workflow_dispatch` and verify it completes successfully
- [ ] Verify that if a concurrent commit lands on main during the build, the rebase + push succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)