### PR TITLE
feat: persist CRL number in snapshot to skip redundant rebuilds

### DIFF
--- a/server/cmd/smtbuild/main.go
+++ b/server/cmd/smtbuild/main.go
@@ -75,11 +75,11 @@ func main() {
 		issuerDir := filepath.Join(cfg.DataDir, iss.ID)
 		snapshotPath := filepath.Join(issuerDir, "tree-snapshot.json.gz")
 
-		tree, err = snapshot.ImportFile(hasher, snapshotPath)
+		tree, _, err = snapshot.ImportFile(hasher, snapshotPath)
 		if err != nil {
 			log.Printf("[%s] No local snapshot, trying GitHub Release", iss.ID)
 			if dlPath, dlErr := snapshot.Download(cfg.GitHubRepo, iss.ID, cfg.DataDir); dlErr == nil {
-				tree, err = snapshot.ImportFile(hasher, dlPath)
+				tree, _, err = snapshot.ImportFile(hasher, dlPath)
 				if err != nil {
 					log.Printf("[%s] Failed to import downloaded snapshot: %v", iss.ID, err)
 				}
@@ -178,7 +178,7 @@ func main() {
 			log.Printf("[%s] Skipping: create snapshot file: %v", iss.ID, err)
 			continue
 		}
-		if err := snapshot.Export(tree, f); err != nil {
+		if err := snapshot.Export(tree, parsed.CRLNumber.Uint64(), f); err != nil {
 			f.Close()
 			log.Printf("[%s] Skipping: export snapshot: %v", iss.ID, err)
 			continue

--- a/server/cmd/smtserver/main.go
+++ b/server/cmd/smtserver/main.go
@@ -36,7 +36,7 @@ func main() {
 	}
 	for _, iss := range issuers {
 		snapPath := filepath.Join(cfg.DataDir, iss.ID, "tree-snapshot.json.gz")
-		tree, err := snapshot.ImportFile(hasher, snapPath)
+		tree, crlNum, err := snapshot.ImportFile(hasher, snapPath)
 		if err != nil {
 			log.Printf("No local snapshot for %s, downloading...", iss.ID)
 			dlPath, dlErr := snapshot.Download(cfg.GitHubRepo, iss.ID, cfg.DataDir)
@@ -44,14 +44,14 @@ func main() {
 				log.Printf("Snapshot download failed for %s: %v", iss.ID, dlErr)
 				continue
 			}
-			tree, err = snapshot.ImportFile(hasher, dlPath)
+			tree, crlNum, err = snapshot.ImportFile(hasher, dlPath)
 			if err != nil {
 				log.Printf("Snapshot import failed for %s: %v", iss.ID, err)
 				continue
 			}
 		}
-		mgr.SetTree(iss.ID, tree, 0) // CRLNumber unknown from snapshot; watcher will update
-		log.Printf("Loaded snapshot for %s: count=%d", iss.ID, tree.Count)
+		mgr.SetTree(iss.ID, tree, crlNum)
+		log.Printf("Loaded snapshot for %s: count=%d crlNumber=%d", iss.ID, tree.Count, crlNum)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/internal/api/e2e_integration_test.go
+++ b/server/internal/api/e2e_integration_test.go
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Import snapshot into SMT.
-	tree, err := snapshot.ImportFile(h, snapshotPath)
+	tree, crlNum, err := snapshot.ImportFile(h, snapshotPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to import snapshot: %v\n", err)
 		os.Exit(1)
@@ -76,7 +76,7 @@ func TestMain(m *testing.M) {
 
 	// Set up TreeManager with the imported tree.
 	mgr := manager.New(h)
-	mgr.SetTree(issuerID, tree, 0)
+	mgr.SetTree(issuerID, tree, crlNum)
 	mgr.SetTree("g3", smt.New(h), 0)
 
 	// Set up REST router.

--- a/server/internal/snapshot/snapshot.go
+++ b/server/internal/snapshot/snapshot.go
@@ -17,8 +17,9 @@ type Snapshot struct {
 	Version int              `json:"version"`
 	Root    string           `json:"root"`
 	Count   int              `json:"count"`
-	Depth   int              `json:"depth,omitempty"`
-	Nodes   []NodeEntry      `json:"nodes"`
+	Depth     int              `json:"depth,omitempty"`
+	CRLNumber uint64           `json:"crlNumber"`
+	Nodes     []NodeEntry      `json:"nodes"`
 }
 
 // NodeEntry is a [nodeHash, [children...]] pair.
@@ -48,15 +49,16 @@ func hexToBig(s string) (*big.Int, error) {
 }
 
 // Export writes the SMT as a gzip-compressed JSON snapshot.
-func Export(tree *smt.SMT, w io.Writer) error {
+func Export(tree *smt.SMT, crlNumber uint64, w io.Writer) error {
 	nodes := tree.Nodes()
 
 	snapshot := Snapshot{
-		Version: 1,
-		Root:    bigToHex(tree.Root),
-		Count:   tree.Count,
-		Depth:   tree.Depth,
-		Nodes:   make([]NodeEntry, 0, len(nodes)),
+		Version:   1,
+		Root:      bigToHex(tree.Root),
+		Count:     tree.Count,
+		Depth:     tree.Depth,
+		CRLNumber: crlNumber,
+		Nodes:     make([]NodeEntry, 0, len(nodes)),
 	}
 
 	for hash, children := range nodes {
@@ -79,31 +81,31 @@ func Export(tree *smt.SMT, w io.Writer) error {
 }
 
 // ImportFile opens a gzip-compressed JSON snapshot file and reconstructs an SMT.
-func ImportFile(h smt.Hasher, path string) (*smt.SMT, error) {
+func ImportFile(h smt.Hasher, path string) (*smt.SMT, uint64, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer f.Close()
 	return Import(h, f)
 }
 
 // Import reads a gzip-compressed JSON snapshot and reconstructs an SMT.
-func Import(h smt.Hasher, r io.Reader) (*smt.SMT, error) {
+func Import(h smt.Hasher, r io.Reader) (*smt.SMT, uint64, error) {
 	gr, err := gzip.NewReader(r)
 	if err != nil {
-		return nil, fmt.Errorf("gzip reader: %w", err)
+		return nil, 0, fmt.Errorf("gzip reader: %w", err)
 	}
 	defer gr.Close()
 
 	var snapshot Snapshot
 	if err := json.NewDecoder(gr).Decode(&snapshot); err != nil {
-		return nil, fmt.Errorf("json decode: %w", err)
+		return nil, 0, fmt.Errorf("json decode: %w", err)
 	}
 
 	root, err := hexToBig(snapshot.Root)
 	if err != nil {
-		return nil, fmt.Errorf("parse root: %w", err)
+		return nil, 0, fmt.Errorf("parse root: %w", err)
 	}
 
 	depth := snapshot.Depth
@@ -115,14 +117,14 @@ func Import(h smt.Hasher, r io.Reader) (*smt.SMT, error) {
 	for _, entry := range snapshot.Nodes {
 		hashBig, err := hexToBig(entry.Hash)
 		if err != nil {
-			return nil, fmt.Errorf("parse node hash: %w", err)
+			return nil, 0, fmt.Errorf("parse node hash: %w", err)
 		}
 
 		children := make(smt.ChildNodes, len(entry.Children))
 		for i, c := range entry.Children {
 			children[i], err = hexToBig(c)
 			if err != nil {
-				return nil, fmt.Errorf("parse child: %w", err)
+				return nil, 0, fmt.Errorf("parse child: %w", err)
 			}
 		}
 
@@ -133,5 +135,5 @@ func Import(h smt.Hasher, r io.Reader) (*smt.SMT, error) {
 	tree := smt.NewWithDepth(h, depth)
 	tree.SetNodes(nodes, root, snapshot.Count)
 
-	return tree, nil
+	return tree, snapshot.CRLNumber, nil
 }

--- a/server/internal/snapshot/snapshot_test.go
+++ b/server/internal/snapshot/snapshot_test.go
@@ -2,6 +2,7 @@ package snapshot
 
 import (
 	"bytes"
+	"compress/gzip"
 	"math/big"
 	"testing"
 
@@ -28,12 +29,12 @@ func TestSnapshotRoundTrip(t *testing.T) {
 
 	// Export
 	var buf bytes.Buffer
-	if err := Export(tree, &buf); err != nil {
+	if err := Export(tree, 0, &buf); err != nil {
 		t.Fatal("export:", err)
 	}
 
 	// Import
-	restored, err := Import(h, &buf)
+	restored, _, err := Import(h, &buf)
 	if err != nil {
 		t.Fatal("import:", err)
 	}
@@ -72,11 +73,11 @@ func TestSnapshotEmpty(t *testing.T) {
 	tree := smt.New(h)
 
 	var buf bytes.Buffer
-	if err := Export(tree, &buf); err != nil {
+	if err := Export(tree, 0, &buf); err != nil {
 		t.Fatal("export empty:", err)
 	}
 
-	restored, err := Import(h, &buf)
+	restored, _, err := Import(h, &buf)
 	if err != nil {
 		t.Fatal("import empty:", err)
 	}
@@ -86,5 +87,50 @@ func TestSnapshotEmpty(t *testing.T) {
 	}
 	if restored.Count != 0 {
 		t.Error("empty tree count should be zero")
+	}
+}
+
+func TestSnapshotCRLNumber(t *testing.T) {
+	h := smt.NewPoseidonHasher()
+	tree := smt.New(h)
+
+	key, _ := new(big.Int).SetString("ABCDEF", 16)
+	tree.Add(key, big.NewInt(1))
+
+	var crlNum uint64 = 42
+
+	var buf bytes.Buffer
+	if err := Export(tree, crlNum, &buf); err != nil {
+		t.Fatal("export:", err)
+	}
+
+	restored, gotCRL, err := Import(h, &buf)
+	if err != nil {
+		t.Fatal("import:", err)
+	}
+
+	if gotCRL != crlNum {
+		t.Errorf("crlNumber: got %d, want %d", gotCRL, crlNum)
+	}
+	if restored.Root.Cmp(tree.Root) != 0 {
+		t.Errorf("root mismatch")
+	}
+}
+
+func TestSnapshotBackwardCompat(t *testing.T) {
+	jsonData := `{"version":1,"root":"0x0","count":0,"nodes":[]}`
+
+	var gzBuf bytes.Buffer
+	gw := gzip.NewWriter(&gzBuf)
+	gw.Write([]byte(jsonData))
+	gw.Close()
+
+	h := smt.NewPoseidonHasher()
+	_, gotCRL, err := Import(h, &gzBuf)
+	if err != nil {
+		t.Fatal("import old format:", err)
+	}
+	if gotCRL != 0 {
+		t.Errorf("old snapshot crlNumber: got %d, want 0", gotCRL)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `crlNumber` field to the snapshot JSON format so it's fully self-describing
- `smtserver` now loads the CRL number from the snapshot instead of hardcoding `0`, so the CRL watcher skips the rebuild when the CRL hasn't changed
- `smtbuild` writes the CRL number into exported snapshots
- Backward compatible: old snapshots without the field decode to `0` (same as current behavior)

## Test plan

- [x] Unit tests: `TestSnapshotCRLNumber` verifies round-trip, `TestSnapshotBackwardCompat` verifies old format
- [x] All existing snapshot tests updated and passing
- [ ] Manual: `make run` should show snapshot load without subsequent "Building SMT" log when CRL is unchanged
- [ ] CI: integration tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)