### PR TITLE
feat: persist snapshot after CRL watcher rebuild

### DIFF
--- a/server/cmd/smtbuild/main.go
+++ b/server/cmd/smtbuild/main.go
@@ -167,24 +167,11 @@ func main() {
 			}
 		}
 
-		// Write output files
-		if err := os.MkdirAll(issuerDir, 0o755); err != nil {
-			log.Printf("[%s] Skipping: mkdir error: %v", iss.ID, err)
-			continue
-		}
-
-		// Export snapshot
-		f, err := os.Create(snapshotPath)
-		if err != nil {
-			log.Printf("[%s] Skipping: create snapshot file: %v", iss.ID, err)
-			continue
-		}
-		if err := snapshot.Export(tree, parsed.CRLNumber.Uint64(), f); err != nil {
-			f.Close()
+		// Export snapshot (atomic write via temp file + rename)
+		if err := snapshot.ExportFile(tree, parsed.CRLNumber.Uint64(), snapshotPath); err != nil {
 			log.Printf("[%s] Skipping: export snapshot: %v", iss.ID, err)
 			continue
 		}
-		f.Close()
 		log.Printf("[%s] Snapshot exported to %s", iss.ID, snapshotPath)
 
 		// Write root.json

--- a/server/cmd/smtserver/main.go
+++ b/server/cmd/smtserver/main.go
@@ -105,6 +105,7 @@ func main() {
 
 	log.Println("Shutting down...")
 	cancel()
+	watcher.Wait()
 	grpcServer.GracefulStop()
 	httpServer.Shutdown(context.Background())
 }

--- a/server/cmd/smtserver/main.go
+++ b/server/cmd/smtserver/main.go
@@ -64,7 +64,7 @@ func main() {
 	}
 	watcher := crl.NewWatcher(
 		time.Duration(cfg.CRLPollInterval)*time.Second,
-		issuers, mgr, hasher,
+		issuers, mgr, hasher, cfg.DataDir,
 	)
 	go watcher.Start(ctx)
 

--- a/server/internal/crl/watcher.go
+++ b/server/internal/crl/watcher.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"log"
 	"math/big"
+	"path/filepath"
 	"time"
 
 	"github.com/moven0831/moica-revocation-smt/server/internal/manager"
+	"github.com/moven0831/moica-revocation-smt/server/internal/snapshot"
 	"github.com/moven0831/moica-revocation-smt/server/internal/smt"
 )
 
@@ -22,15 +24,17 @@ type Watcher struct {
 	issuers  []IssuerConfig
 	mgr      *manager.TreeManager
 	hasher   smt.Hasher
+	dataDir  string
 }
 
 // NewWatcher creates a CRL watcher that polls at the given interval.
-func NewWatcher(interval time.Duration, issuers []IssuerConfig, mgr *manager.TreeManager, hasher smt.Hasher) *Watcher {
+func NewWatcher(interval time.Duration, issuers []IssuerConfig, mgr *manager.TreeManager, hasher smt.Hasher, dataDir string) *Watcher {
 	return &Watcher{
 		interval: interval,
 		issuers:  issuers,
 		mgr:      mgr,
 		hasher:   hasher,
+		dataDir:  dataDir,
 	}
 }
 
@@ -101,6 +105,16 @@ func (w *Watcher) fetchAndRebuild(issuer IssuerConfig) error {
 	w.mgr.SetTree(issuer.ID, tree, crlNum)
 	log.Printf("SMT for %s loaded: root=%s count=%d crl=%d",
 		issuer.ID, tree.Root.Text(16)[:16]+"...", tree.Count, crlNum)
+
+	// Persist snapshot to disk so future restarts load fresh data instantly
+	go func() {
+		snapPath := filepath.Join(w.dataDir, issuer.ID, "tree-snapshot.json.gz")
+		if err := snapshot.ExportFile(tree, crlNum, snapPath); err != nil {
+			log.Printf("Snapshot export failed for %s: %v", issuer.ID, err)
+		} else {
+			log.Printf("Snapshot exported for %s to %s", issuer.ID, snapPath)
+		}
+	}()
 
 	return nil
 }

--- a/server/internal/crl/watcher.go
+++ b/server/internal/crl/watcher.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"math/big"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/moven0831/moica-revocation-smt/server/internal/manager"
@@ -25,6 +26,7 @@ type Watcher struct {
 	mgr      *manager.TreeManager
 	hasher   smt.Hasher
 	dataDir  string
+	wg       sync.WaitGroup
 }
 
 // NewWatcher creates a CRL watcher that polls at the given interval.
@@ -37,6 +39,9 @@ func NewWatcher(interval time.Duration, issuers []IssuerConfig, mgr *manager.Tre
 		dataDir:  dataDir,
 	}
 }
+
+// Wait blocks until all background export goroutines have finished.
+func (w *Watcher) Wait() { w.wg.Wait() }
 
 // Start begins the periodic CRL polling loop. Blocks until ctx is cancelled.
 func (w *Watcher) Start(ctx context.Context) {
@@ -107,7 +112,9 @@ func (w *Watcher) fetchAndRebuild(issuer IssuerConfig) error {
 		issuer.ID, tree.Root.Text(16)[:16]+"...", tree.Count, crlNum)
 
 	// Persist snapshot to disk so future restarts load fresh data instantly
+	w.wg.Add(1)
 	go func() {
+		defer w.wg.Done()
 		snapPath := filepath.Join(w.dataDir, issuer.ID, "tree-snapshot.json.gz")
 		if err := snapshot.ExportFile(tree, crlNum, snapPath); err != nil {
 			log.Printf("Snapshot export failed for %s: %v", issuer.ID, err)

--- a/server/internal/snapshot/snapshot.go
+++ b/server/internal/snapshot/snapshot.go
@@ -88,11 +88,11 @@ func ExportFile(tree *smt.SMT, crlNumber uint64, path string) error {
 		return fmt.Errorf("mkdir: %w", err)
 	}
 
-	tmpPath := path + ".tmp"
-	f, err := os.Create(tmpPath)
+	f, err := os.CreateTemp(filepath.Dir(path), "snapshot-*.tmp")
 	if err != nil {
 		return fmt.Errorf("create tmp: %w", err)
 	}
+	tmpPath := f.Name()
 
 	if err := Export(tree, crlNumber, f); err != nil {
 		f.Close()

--- a/server/internal/snapshot/snapshot.go
+++ b/server/internal/snapshot/snapshot.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/big"
 	"os"
+	"path/filepath"
 
 	"github.com/moven0831/moica-revocation-smt/server/internal/smt"
 )
@@ -78,6 +79,36 @@ func Export(tree *smt.SMT, crlNumber uint64, w io.Writer) error {
 
 	enc := json.NewEncoder(gw)
 	return enc.Encode(snapshot)
+}
+
+// ExportFile atomically writes an SMT snapshot to the given path.
+// It writes to a temp file first, then renames for crash safety.
+func ExportFile(tree *smt.SMT, crlNumber uint64, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+
+	tmpPath := path + ".tmp"
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("create tmp: %w", err)
+	}
+
+	if err := Export(tree, crlNumber, f); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("export: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("close: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
 }
 
 // ImportFile opens a gzip-compressed JSON snapshot file and reconstructs an SMT.

--- a/server/internal/snapshot/snapshot_test.go
+++ b/server/internal/snapshot/snapshot_test.go
@@ -3,6 +3,8 @@ package snapshot
 import (
 	"bytes"
 	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/moven0831/moica-revocation-smt/server/internal/smt"
@@ -64,6 +66,58 @@ func TestSnapshotRoundTrip(t *testing.T) {
 	}
 	if !smt.VerifyProof(h, nonProof, smt.DefaultDepth) {
 		t.Fatal("non-membership proof verification failed on restored tree")
+	}
+}
+
+func TestExportFileRoundTrip(t *testing.T) {
+	h := smt.NewPoseidonHasher()
+	tree := smt.New(h)
+
+	serials := []string{
+		"100048210DD2DF2E128096A9282B5EC5",
+		"200048210DD2DF2E128096A9282B5EC5",
+		"300048210DD2DF2E128096A9282B5EC5",
+	}
+	for _, s := range serials {
+		key, _ := new(big.Int).SetString(s, 16)
+		tree.Add(key, big.NewInt(1))
+	}
+
+	originalRoot := new(big.Int).Set(tree.Root)
+	originalCount := tree.Count
+	var crlNum uint64 = 99
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "tree-snapshot.json.gz")
+
+	if err := ExportFile(tree, crlNum, path); err != nil {
+		t.Fatal("ExportFile:", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal("snapshot file not found:", err)
+	}
+
+	restored, gotCRL, err := ImportFile(h, path)
+	if err != nil {
+		t.Fatal("ImportFile:", err)
+	}
+	if restored.Root.Cmp(originalRoot) != 0 {
+		t.Errorf("root mismatch: got %s, want %s", restored.Root.Text(16), originalRoot.Text(16))
+	}
+	if restored.Count != originalCount {
+		t.Errorf("count mismatch: got %d, want %d", restored.Count, originalCount)
+	}
+	if gotCRL != crlNum {
+		t.Errorf("crlNumber: got %d, want %d", gotCRL, crlNum)
+	}
+
+	// Verify no .tmp files remain
+	entries, _ := os.ReadDir(filepath.Dir(path))
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("stale temp file found: %s", e.Name())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `ExportFile` to the snapshot package for atomic writes (temp file + rename)
- CRL watcher now async-exports the rebuilt tree to disk after `SetTree`, so future restarts load fresh data instantly without a full rebuild (~minutes for G2's 412k serials)
- Refactor `smtbuild` CLI to reuse `ExportFile`, reducing duplication and gaining atomic write safety

## Test plan
- [x] `make build` and `make build-cli` compile successfully
- [x] `make test` — all unit tests pass
- [ ] `make run` — server starts, CRL watcher triggers, observe log: "Snapshot exported for g2 to ..."
- [ ] Kill server, `make run` again — snapshot loads from freshly exported file, watcher logs "CRL is not newer, skipping"

🤖 Generated with [Claude Code](https://claude.com/claude-code)