### PR TITLE
fix: update G3 CRL URL to correct endpoint

### DIFF
--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -34,7 +34,7 @@ func Load() *Config {
 		GRPCPort:          getEnvInt("GRPC_PORT", 50051),
 		DataDir:           getEnv("DATA_DIR", "./data"),
 		CRLG2URL:          getEnv("CRL_G2_URL", "https://moica.nat.gov.tw/repository/MOICA/CRL2/complete.crl"),
-		CRLG3URL:          getEnv("CRL_G3_URL", "https://moica.nat.gov.tw/repository/MOICA/CRL3/complete.crl"),
+		CRLG3URL:          getEnv("CRL_G3_URL", "https://crl-moica.moi.gov.tw/crl/MOICA-G3-complete.crl"),
 		CRLPollInterval:   getEnvInt("CRL_POLL_INTERVAL", 21600), // 6 hours
 		RPCURL:            getEnv("RPC_URL", ""),
 		RelayerPrivateKey: getEnv("RELAYER_PRIVATE_KEY", ""),

--- a/server/internal/crl/integration_test.go
+++ b/server/internal/crl/integration_test.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	crlG2URL = "https://moica.nat.gov.tw/repository/MOICA/CRL2/complete.crl"
-	crlG3URL = "https://moica.nat.gov.tw/repository/MOICA/CRL3/complete.crl"
+	crlG3URL = "https://crl-moica.moi.gov.tw/crl/MOICA-G3-complete.crl"
 )
 
 func TestIntegrationG2CRL(t *testing.T) {


### PR DESCRIPTION
## Summary
- Updated the G3 CRL URL from `https://moica.nat.gov.tw/repository/MOICA/CRL3/complete.crl` to `https://crl-moica.moi.gov.tw/crl/MOICA-G3-complete.crl`
- Changed the default URL in `server/internal/config/config.go`
- Changed the integration test constant in `server/internal/crl/integration_test.go`

## Test plan
- [x] `make build` — compilation succeeds
- [x] `make test` — all unit tests pass
- [x] `curl -I https://crl-moica.moi.gov.tw/crl/MOICA-G3-complete.crl` — verify URL is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)