### PR TITLE
docs: add deployed SMTRootStorage contract address

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,13 @@ Service `RevocationProofService` on port 50051 with `GetProof` and `GetStatus` R
 
 **SMTRootStorage.sol** — on-chain registry for SMT roots.
 
+**Deployed on Arbitrum Sepolia:** [`0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA`](https://sepolia.arbiscan.io/address/0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA)
+
+The contract stores SMT Merkle roots on-chain so anyone can verify certificate revocation status against a trusted root. A CI relayer updates roots twice daily after rebuilding from MOICA CRL data. Each root is tied to a monotonically increasing CRL number to prevent stale updates. Anyone can call `getRoot(issuerId)` to read the latest root and verify proofs off-chain.
+
 | Function | Description |
 |----------|-------------|
-| `setRoot(bytes32 issuerId, uint256 root, uint256 crlNumber)` | Update root (relayer only, monotonic CRL number) |
+| `setRoot(bytes32 issuerId, uint256 newRoot, uint256 crlNumber)` | Update root (relayer only, monotonic CRL number) |
 | `getRoot(bytes32 issuerId) → uint256` | Read current root |
 
 Issuer IDs: `keccak256("MOICA-G2")`, `keccak256("MOICA-G3")`

--- a/onchain-contract/README.md
+++ b/onchain-contract/README.md
@@ -2,6 +2,14 @@
 
 On-chain registry for Sparse Merkle Tree roots from MOICA Certificate Revocation Lists.
 
+## Deployed Contract
+
+| Network | Address |
+|---------|---------|
+| Arbitrum Sepolia | [`0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA`](https://sepolia.arbiscan.io/address/0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA) |
+
+The CRL pipeline (fetch → parse → build SMT) produces a Merkle root per issuer, which the CI relayer posts on-chain via `setRoot()`. The contract enforces monotonic CRL numbers to prevent stale updates. Anyone can read the latest root with `getRoot(issuerId)` and verify membership/non-membership proofs off-chain.
+
 ## Contract
 
 **SMTRootStorage.sol** (Solidity 0.8.28)


### PR DESCRIPTION
## Summary
- Add the live SMTRootStorage contract address on Arbitrum Sepolia (`0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA`) with Arbiscan explorer link to both `README.md` and `onchain-contract/README.md`
- Include brief explanation of how roots flow from CRL → SMT → on-chain and how anyone can verify proofs

## Test plan
- [ ] Verify Arbiscan link resolves correctly
- [ ] Review rendered markdown in both READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)