### PR TITLE
feat: add WASM module and binary snapshot for client-side SMT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,20 @@ jobs:
       - run: go mod download
       - run: go test ./internal/chain/ -v
 
+  wasm-build:
+    name: WASM Build Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - run: go mod download
+      - run: GOOS=js GOARCH=wasm go build -o /dev/null ./wasm/
+
   integration:
     name: Integration Tests (E2E with snapshot)
     runs-on: ubuntu-latest

--- a/.github/workflows/update-smt.yml
+++ b/.github/workflows/update-smt.yml
@@ -25,9 +25,12 @@ jobs:
       - name: Build CLI
         run: go build -o bin/smtbuild ./cmd/smtbuild
 
+      - name: Build WASM
+        run: GOOS=js GOARCH=wasm go build -o wasm/smt.wasm ./wasm/
+
       - name: Fetch CRL & Build SMT
         id: build
-        run: ./bin/smtbuild
+        run: ./bin/smtbuild --binary
         env:
           DATA_DIR: ./data
 
@@ -51,11 +54,21 @@ jobs:
           notes="Auto-updated SMT snapshot $(date -u +%Y-%m-%dT%H:%M:%SZ)"$'\n\n'
           for gen in g2 g3; do
             src="data/${gen}/tree-snapshot.json.gz"
+            bin_src="data/${gen}/tree-snapshot.bin.gz"
             root_file="data/${gen}/root.json"
             if [ -f "$src" ]; then
               dest="data/${gen}/${gen}-tree-snapshot.json.gz"
               cp "$src" "$dest"
               assets="$assets $dest"
+            fi
+            if [ -f "$bin_src" ]; then
+              bin_dest="data/${gen}/${gen}-tree-snapshot.bin.gz"
+              cp "$bin_src" "$bin_dest"
+              assets="$assets $bin_dest"
+              # Generate uncompressed variant for mobile clients
+              bin_uncompressed="data/${gen}/${gen}-tree-snapshot.bin"
+              gunzip -c "$bin_src" > "$bin_uncompressed"
+              assets="$assets $bin_uncompressed"
             fi
             if [ -f "$root_file" ]; then
               root=$(jq -r '.root' "$root_file")
@@ -69,6 +82,16 @@ jobs:
               notes+="- **Updated:** ${ts}"$'\n\n'
             fi
           done
+          # Add WASM module assets
+          if [ -f "wasm/smt.wasm" ]; then
+            assets="$assets wasm/smt.wasm"
+          fi
+          WASM_JS="$(go env GOROOT)/lib/wasm/wasm_exec.js"
+          if [ ! -f "$WASM_JS" ]; then WASM_JS="$(go env GOROOT)/misc/wasm/wasm_exec.js"; fi
+          if [ -f "$WASM_JS" ]; then
+            cp "$WASM_JS" wasm/wasm_exec.js
+            assets="$assets wasm/wasm_exec.js"
+          fi
           if [ -n "$assets" ]; then
             gh release create snapshot-latest \
               --title "SMT Snapshot" \

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,15 @@
 # Snapshot binaries (kept in GitHub Releases only)
 server/data/**/*.json.gz
+server/data/**/*.bin.gz
 
-# Go server
+# Go build output
 server/bin/
+server/smtbuild
+
+# WASM build output (kept in GitHub Releases only)
+server/wasm/smt.wasm
+server/wasm/wasm_exec.js
+server/wasm/tree-snapshot.bin.gz
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ curl -L -o data/g3/tree-snapshot.json.gz \
   https://github.com/moven0831/moica-revocation-smt/releases/download/snapshot-latest/g3-tree-snapshot.json.gz
 ```
 
-Snapshots are gzip-compressed JSON containing the full SMT node tree, compatible with `@zk-kit/smt` v1.0.2.
+Snapshots are available in two formats:
+- **JSON** (`.json.gz`) — compatible with `@zk-kit/smt` v1.0.2, used by the server
+- **Binary** (`.bin.gz` / `.bin`) — compact format for client-side WASM loading (see [Client-Side WASM](#client-side-wasm))
 
 The latest Merkle roots for each issuer are displayed in the [snapshot-latest release notes](https://github.com/moven0831/moica-revocation-smt/releases/tag/snapshot-latest). Since the SMT is deterministic, anyone can independently verify a root by rebuilding from the same CRL data.
 
@@ -167,17 +169,111 @@ See [onchain-contract/README.md](onchain-contract/README.md) for detailed setup 
 | `CONTRACT_ADDRESS` | — | SMTRootStorage contract address |
 | `GITHUB_REPO` | `moven0831/moica-revocation-smt` | GitHub repo for snapshot releases |
 
+## Client-Side WASM
+
+A Go WASM module (`smt.wasm`, ~3.3MB) enables loading the full SMT and generating proofs entirely in the browser — no server round-trip needed.
+
+### WASM API
+
+Build: `cd server && make build-wasm` (requires Go 1.24+)
+
+The WASM module exposes these functions on `globalThis`:
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `smtInitTree` | `(nodeCount, depth)` | Pre-allocate tree structure |
+| `smtAddNodeChunk` | `(Uint8Array)` → `number` | Stream binary nodes in chunks, returns count parsed |
+| `smtFinalize` | `(rootHex, leafCount)` | Set root and finalize tree for proof generation |
+| `smtCreateProof` | `(keyHex)` → `string` | Generate proof, returns JSON with `root`, `entry`, `matchingEntry`, `siblings` |
+| `smtVerifyProof` | `(proofJSON)` → `boolean` | Verify a proof |
+| `smtGetMemStats` | `()` → `string` | Go runtime memory stats as JSON |
+
+Proof output format: all values are bare hex (no `0x` prefix), matching the server's REST API structure.
+
+### Binary Snapshot Format
+
+The binary format is a compact representation of the SMT node tree, designed for efficient chunked streaming to WASM.
+
+**Header** (52 bytes, big-endian):
+```
+[0:2]   magic       uint16  0x534D ("SM")
+[2:4]   version     uint16  1
+[4:8]   nodeCount   uint32
+[8:40]  rootHash    [32]byte
+[40:44] depth       uint32
+[44:52] crlNumber   uint64
+```
+
+**Per node** (variable size):
+```
+[0:1]   type    uint8   (0=branch, 1=leaf)
+[1:33]  hash    [32]byte
+Branch: [33:65] left [32]byte, [65:97] right [32]byte    (97 bytes total)
+Leaf:   [33:65] key [32]byte, [65:97] value [32]byte, [97:129] entryMark [32]byte    (129 bytes total)
+```
+
+Build binary snapshots: `cd server && make build-binary` or `./bin/smtbuild --binary`
+
+Convert existing JSON snapshot: `./bin/smtbuild --convert-binary data/g2/tree-snapshot.json.gz`
+
+### Client Integration Guide
+
+Web or mobile clients can use the published release artifacts to load an SMT and generate proofs locally:
+
+1. **Load runtime** — include `wasm_exec.js` (Go's JS glue), instantiate `smt.wasm` via `WebAssembly.instantiateStreaming`
+2. **Fetch snapshot** — download `g2-tree-snapshot.bin.gz` (desktop, decompress via `DecompressionStream`) or `g2-tree-snapshot.bin` (mobile, no decompression needed)
+3. **Build tree** — parse 52-byte binary header → `smtInitTree(nodeCount, depth)` → stream nodes via `smtAddNodeChunk(chunk)` in batches of ~10,000 → `smtFinalize(rootHex, leafCount)`
+4. **Generate proof** — `smtCreateProof(serialNumberHex)` → parse JSON → convert hex to decimal strings → pad siblings to depth 128
+5. **Feed to circuit** — proof fields (`smtRoot`, `smtSiblings[128]`, `smtOldKey`, `smtOldValue`, `smtIsOld0`) become inputs for `SMTNonMembershipVerifier(128)` in the [zkID](https://github.com/zkmopro/zkID) circom circuit
+
+### Release Assets
+
+The `snapshot-latest` release (updated twice daily) includes:
+
+| Asset | Size | Description |
+|-------|------|-------------|
+| `smt.wasm` | ~3.3MB | Go WASM module |
+| `wasm_exec.js` | ~17KB | Go WASM runtime support |
+| `g2-tree-snapshot.bin.gz` | ~71MB | Compressed binary snapshot (desktop) |
+| `g2-tree-snapshot.bin` | ~105MB | Uncompressed binary snapshot (mobile) |
+| `g2-tree-snapshot.json.gz` | ~76MB | JSON snapshot (server) |
+
+### Performance (Benchmark)
+
+| Metric | Desktop (M3, Chrome) | iPhone (Safari) | Android (Chrome) |
+|--------|---------------------|-----------------|------------------|
+| Download | 6ms (localhost) | 103ms | 157ms |
+| Decompress (.bin.gz) | 296ms | 14.4s | 14.9s |
+| Tree load | 2.85s | 1.74s | 5.86s |
+| Proof generation | <1ms | 1ms | 3ms |
+| WASM heap | 442MB | 424MB | 424MB |
+| **Total** | **3.2s** | **16.3s** | **21.1s** |
+
+**Tip:** Serving uncompressed `.bin` (no gzip) eliminates the mobile decompression bottleneck, reducing mobile total time to ~2-7s.
+
+Run the benchmark locally: `cd server && make benchmark` → opens `http://localhost:8080/benchmark.html`
+
+### Mobile Integration Path
+
+The same binary snapshot and proof format work across platforms:
+
+- **Web** — Go WASM (`smt.wasm`) loaded via `wasm_exec.js` + `WebAssembly.instantiateStreaming`
+- **Mobile (Flutter/React Native)** — Go mobile bindings via `gomobile bind` or Rust FFI reimplementation using the same binary format
+- **Proof conversion** — hex-to-decimal + sibling padding is ~50 lines of platform-agnostic logic, easily ported to any language
+- **Circuit** — same `SMTNonMembershipVerifier(128)` circom circuit, same witness format; [mopro](https://github.com/zkmopro/mopro) handles mobile proving
+
 ## CI/CD
 
 **`ci.yml`** — runs on push/PR to main:
 - Go server: `go test ./...` + build binary
+- WASM: verify `smt.wasm` compiles (`GOOS=js GOARCH=wasm`)
 - E2E integration: downloads real G2 snapshot (~412k entries), verifies proofs via REST + gRPC
 - Contracts: `npx hardhat test` (Node 22)
 
 **`update-smt.yml`** — runs twice daily at 12:00/00:00 UTC+8 (04:00/16:00 UTC):
-1. Build server binary
-2. Fetch CRL, build SMT, export snapshot (skipped if merkle root is unchanged)
-3. Upload snapshot to GitHub Release
+1. Build server binary + WASM module
+2. Fetch CRL, build SMT, export JSON + binary snapshots (skipped if merkle root is unchanged)
+3. Upload snapshots, WASM module, and `wasm_exec.js` to GitHub Release (`snapshot-latest`)
 4. Post root on-chain via `smtbuild --post-root` (Arbitrum Sepolia)
 
 Required secrets: `RPC_URL`, `RELAYER_PRIVATE_KEY`, `CONTRACT_ADDRESS` (on-chain posting skips gracefully if unset)

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Run the benchmark locally: `cd server && make benchmark` → opens `http://local
 The same binary snapshot and proof format work across platforms:
 
 - **Web** — Go WASM (`smt.wasm`) loaded via `wasm_exec.js` + `WebAssembly.instantiateStreaming`
-- **Mobile (Flutter/React Native)** — Go mobile bindings via `gomobile bind` or Rust FFI reimplementation using the same binary format
+- **Mobile (iOS/Android)** — Go mobile bindings via `gomobile bind` (`.xcframework` for Swift, `.aar` for Kotlin) using the same binary format
 - **Proof conversion** — hex-to-decimal + sibling padding is ~50 lines of platform-agnostic logic, easily ported to any language
 - **Circuit** — same `SMTNonMembershipVerifier(128)` circom circuit, same witness format; [mopro](https://github.com/zkmopro/mopro) handles mobile proving
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,10 +1,29 @@
-.PHONY: build build-cli test test-integration proto clean
+.PHONY: build build-cli build-wasm build-binary test test-integration proto clean
 
 build:
 	go build -o bin/smtserver ./cmd/smtserver
 
 build-cli:
 	go build -o bin/smtbuild ./cmd/smtbuild
+
+build-wasm:
+	GOOS=js GOARCH=wasm go build -o wasm/smt.wasm ./wasm/
+	@WASM_JS="$$(go env GOROOT)/lib/wasm/wasm_exec.js"; \
+	if [ ! -f "$$WASM_JS" ]; then WASM_JS="$$(go env GOROOT)/misc/wasm/wasm_exec.js"; fi; \
+	cp "$$WASM_JS" wasm/
+
+build-binary: build-cli
+	./bin/smtbuild --binary
+
+benchmark: build-cli build-wasm
+	@echo "Converting G2 JSON snapshot to binary..."
+	./bin/smtbuild --convert-binary data/g2/tree-snapshot.json.gz
+	cp data/g2/tree-snapshot.bin.gz wasm/
+	@echo ""
+	@echo "=== Ready ==="
+	@echo "Serving at http://localhost:8080/benchmark.html"
+	@echo "Press Ctrl+C to stop"
+	@cd wasm && python3 -m http.server 8080
 
 test:
 	go test ./... -v

--- a/server/cmd/smtbuild/main.go
+++ b/server/cmd/smtbuild/main.go
@@ -33,9 +33,16 @@ type rootInfo struct {
 
 func main() {
 	postRoot := flag.Bool("post-root", false, "Post SMT roots on-chain (reads root.json files, skips SMT build)")
+	exportBinary := flag.Bool("binary", false, "Also export binary format snapshot alongside JSON")
+	convertBinary := flag.String("convert-binary", "", "Convert JSON snapshot to binary format (path to .json.gz input)")
 	flag.Parse()
 
 	cfg := config.Load()
+
+	if *convertBinary != "" {
+		convertJSONToBinary(*convertBinary)
+		return
+	}
 
 	if *postRoot {
 		postRootOnChain(cfg)
@@ -186,6 +193,15 @@ func main() {
 		}
 		log.Printf("[%s] Snapshot exported to %s", iss.ID, snapshotPath)
 
+		if *exportBinary {
+			binaryPath := filepath.Join(issuerDir, "tree-snapshot.bin.gz")
+			if err := snapshot.ExportBinaryFile(tree, parsed.CRLNumber.Uint64(), binaryPath); err != nil {
+				log.Printf("[%s] Warning: binary export failed: %v", iss.ID, err)
+			} else {
+				log.Printf("[%s] Binary snapshot exported to %s", iss.ID, binaryPath)
+			}
+		}
+
 		// Write root.json
 		info := rootInfo{
 			Root:      newRoot,
@@ -300,6 +316,34 @@ func postRootOnChain(cfg *config.Config) {
 	}
 
 	log.Println("Done — on-chain posting complete")
+}
+
+func convertJSONToBinary(jsonPath string) {
+	hasher := smt.NewPoseidonHasher()
+
+	log.Printf("Loading JSON snapshot from %s", jsonPath)
+	tree, crlNumber, err := snapshot.ImportFile(hasher, jsonPath)
+	if err != nil {
+		log.Fatalf("Failed to import JSON snapshot: %v", err)
+	}
+	log.Printf("Loaded: %d entries, root=0x%s, CRL#%d", tree.Count, tree.Root.Text(16)[:16], crlNumber)
+
+	// Output path: same directory, replace .json.gz with .bin.gz
+	outPath := strings.TrimSuffix(jsonPath, ".json.gz") + ".bin.gz"
+	log.Printf("Exporting binary snapshot to %s", outPath)
+	if err := snapshot.ExportBinaryFile(tree, crlNumber, outPath); err != nil {
+		log.Fatalf("Failed to export binary: %v", err)
+	}
+
+	// Report sizes
+	jsonInfo, _ := os.Stat(jsonPath)
+	binInfo, _ := os.Stat(outPath)
+	if jsonInfo != nil && binInfo != nil {
+		log.Printf("JSON: %d bytes, Binary: %d bytes (%.1f%%)",
+			jsonInfo.Size(), binInfo.Size(),
+			float64(binInfo.Size())/float64(jsonInfo.Size())*100)
+	}
+	log.Println("Done")
 }
 
 func readExistingRoot(path string) (string, error) {

--- a/server/cmd/smtbuild/main.go
+++ b/server/cmd/smtbuild/main.go
@@ -326,7 +326,11 @@ func convertJSONToBinary(jsonPath string) {
 	if err != nil {
 		log.Fatalf("Failed to import JSON snapshot: %v", err)
 	}
-	log.Printf("Loaded: %d entries, root=0x%s, CRL#%d", tree.Count, tree.Root.Text(16)[:16], crlNumber)
+	rootHex := tree.Root.Text(16)
+	if len(rootHex) > 16 {
+		rootHex = rootHex[:16]
+	}
+	log.Printf("Loaded: %d entries, root=0x%s, CRL#%d", tree.Count, rootHex, crlNumber)
 
 	// Output path: same directory, replace .json.gz with .bin.gz
 	outPath := strings.TrimSuffix(jsonPath, ".json.gz") + ".bin.gz"

--- a/server/data/g2/root.json
+++ b/server/data/g2/root.json
@@ -1,6 +1,6 @@
 {
-  "root": "0x632e71742352b249bef13adb76152e04246c0e6180d436d6bc862f5fc9a94177",
-  "count": 408747,
-  "crlNumber": "2026040710",
-  "timestamp": "2026-04-07T05:17:55Z"
+  "root": "0x61870abeb8c161f0fdf34f167ac36830c57ef49843bcc7c14672138e510e13e9",
+  "count": 408761,
+  "crlNumber": "2026040923",
+  "timestamp": "2026-04-09T18:29:19Z"
 }

--- a/server/data/g2/root.json
+++ b/server/data/g2/root.json
@@ -1,6 +1,6 @@
 {
-  "root": "0x92e0368438702ef65b0efd053805ff753674aad899b19c63afcaa92478311aee",
-  "count": 409489,
-  "crlNumber": "2026040523",
-  "timestamp": "2026-04-05T16:14:56Z"
+  "root": "0x632e71742352b249bef13adb76152e04246c0e6180d436d6bc862f5fc9a94177",
+  "count": 408747,
+  "crlNumber": "2026040710",
+  "timestamp": "2026-04-07T05:17:55Z"
 }

--- a/server/data/g3/root.json
+++ b/server/data/g3/root.json
@@ -1,6 +1,6 @@
 {
-  "root": "0x9de8ad4d174118ecf3398f510f837af50922a1ff9ba7797d74dd4d8c487466f7",
-  "count": 109453,
-  "crlNumber": "2026040610",
-  "timestamp": "2026-04-06T05:03:57Z"
+  "root": "0xcea7bc31076eb06247f8ba60303c4de1e7e87eaf4e7805591134394ddcf4cf2d",
+  "count": 110815,
+  "crlNumber": "2026040923",
+  "timestamp": "2026-04-09T18:56:57Z"
 }

--- a/server/internal/smt/tree.go
+++ b/server/internal/smt/tree.go
@@ -175,6 +175,42 @@ func (t *SMT) Nodes() map[string]ChildNodes {
 	return t.nodes
 }
 
+// RawNode holds a single node's data as fixed-size byte arrays for binary export.
+type RawNode struct {
+	IsLeaf   bool
+	Hash     [32]byte
+	Children [][32]byte // 2 for branch, 3 for leaf
+}
+
+// bigTo32 writes a big.Int into a zero-padded 32-byte big-endian array.
+func bigTo32(n *big.Int) [32]byte {
+	var buf [32]byte
+	if n != nil && n.Sign() > 0 {
+		n.FillBytes(buf[:])
+	}
+	return buf
+}
+
+// NodesRaw returns all nodes as RawNode slices for efficient binary export.
+func (t *SMT) NodesRaw() []RawNode {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make([]RawNode, 0, len(t.nodes))
+	for hashHex, cn := range t.nodes {
+		hashBig, _ := new(big.Int).SetString(hashHex, 16)
+		rn := RawNode{
+			IsLeaf:   cn.IsLeaf(),
+			Hash:     bigTo32(hashBig),
+			Children: make([][32]byte, len(cn)),
+		}
+		for i, c := range cn {
+			rn.Children[i] = bigTo32(c)
+		}
+		out = append(out, rn)
+	}
+	return out
+}
+
 // Keys returns copies of all leaf keys (serial numbers) in the tree.
 func (t *SMT) Keys() []*big.Int {
 	t.mu.RLock()

--- a/server/internal/snapshot/binary.go
+++ b/server/internal/snapshot/binary.go
@@ -1,0 +1,233 @@
+package snapshot
+
+import (
+	"compress/gzip"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/moven0831/moica-revocation-smt/server/internal/smt"
+)
+
+// Binary format constants.
+const (
+	BinaryMagic   = 0x534D // "SM"
+	BinaryVersion = 1
+	BinaryHeader  = 52 // 2+2+4+32+4+8 bytes
+)
+
+// ExportBinary writes the SMT as an uncompressed binary snapshot.
+// Caller is responsible for gzip wrapping if desired.
+//
+// Format:
+//
+//	HEADER (52 bytes):
+//	  [0:2]   magic       uint16  0x534D
+//	  [2:4]   version     uint16  1
+//	  [4:8]   nodeCount   uint32
+//	  [8:40]  rootHash    [32]byte
+//	  [40:44] depth       uint32
+//	  [44:52] crlNumber   uint64
+//
+//	PER NODE:
+//	  [0:1]   type        uint8   0=branch, 1=leaf
+//	  [1:33]  hash        [32]byte
+//	  Branch: [33:65] left [32]byte, [65:97] right [32]byte
+//	  Leaf:   [33:65] key [32]byte, [65:97] value [32]byte, [97:129] entryMark [32]byte
+func ExportBinary(tree *smt.SMT, crlNumber uint64, w io.Writer) error {
+	nodes := tree.NodesRaw()
+
+	// Write header
+	var hdr [BinaryHeader]byte
+	binary.BigEndian.PutUint16(hdr[0:2], BinaryMagic)
+	binary.BigEndian.PutUint16(hdr[2:4], BinaryVersion)
+	binary.BigEndian.PutUint32(hdr[4:8], uint32(len(nodes)))
+	root32 := bigTo32Bytes(tree.Root)
+	copy(hdr[8:40], root32[:])
+	binary.BigEndian.PutUint32(hdr[40:44], uint32(tree.Depth))
+	binary.BigEndian.PutUint64(hdr[44:52], crlNumber)
+
+	if _, err := w.Write(hdr[:]); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+
+	// Write nodes
+	for _, rn := range nodes {
+		var typ byte
+		if rn.IsLeaf {
+			typ = 1
+		}
+		if err := writeByte(w, typ); err != nil {
+			return fmt.Errorf("write node type: %w", err)
+		}
+		if _, err := w.Write(rn.Hash[:]); err != nil {
+			return fmt.Errorf("write node hash: %w", err)
+		}
+		for _, child := range rn.Children {
+			if _, err := w.Write(child[:]); err != nil {
+				return fmt.Errorf("write child: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ImportBinary reads an uncompressed binary snapshot and reconstructs an SMT.
+// Caller is responsible for gzip decompression if needed.
+func ImportBinary(h smt.Hasher, r io.Reader) (*smt.SMT, uint64, error) {
+	// Read header
+	var hdr [BinaryHeader]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, 0, fmt.Errorf("read header: %w", err)
+	}
+
+	magic := binary.BigEndian.Uint16(hdr[0:2])
+	if magic != BinaryMagic {
+		return nil, 0, fmt.Errorf("invalid magic: 0x%04X (expected 0x%04X)", magic, BinaryMagic)
+	}
+
+	version := binary.BigEndian.Uint16(hdr[2:4])
+	if version != BinaryVersion {
+		return nil, 0, fmt.Errorf("unsupported version: %d (expected %d)", version, BinaryVersion)
+	}
+
+	nodeCount := binary.BigEndian.Uint32(hdr[4:8])
+	var rootHash [32]byte
+	copy(rootHash[:], hdr[8:40])
+	root := new(big.Int).SetBytes(rootHash[:])
+
+	depth := binary.BigEndian.Uint32(hdr[40:44])
+	crlNumber := binary.BigEndian.Uint64(hdr[44:52])
+
+	// Read nodes
+	nodes := make(map[string]smt.ChildNodes, nodeCount)
+	count := 0
+
+	var typeBuf [1]byte
+	var hashBuf [32]byte
+	var childBuf [32]byte
+
+	for i := uint32(0); i < nodeCount; i++ {
+		if _, err := io.ReadFull(r, typeBuf[:]); err != nil {
+			return nil, 0, fmt.Errorf("read node %d type: %w (expected %d nodes)", i, err, nodeCount)
+		}
+
+		if _, err := io.ReadFull(r, hashBuf[:]); err != nil {
+			return nil, 0, fmt.Errorf("read node %d hash: %w", i, err)
+		}
+
+		isLeaf := typeBuf[0] == 1
+		numChildren := 2
+		if isLeaf {
+			numChildren = 3
+		}
+
+		children := make(smt.ChildNodes, numChildren)
+		for j := 0; j < numChildren; j++ {
+			if _, err := io.ReadFull(r, childBuf[:]); err != nil {
+				return nil, 0, fmt.Errorf("read node %d child %d: %w", i, j, err)
+			}
+			children[j] = new(big.Int).SetBytes(childBuf[:])
+		}
+
+		hashKey := new(big.Int).SetBytes(hashBuf[:]).Text(16)
+		nodes[hashKey] = children
+
+		if isLeaf {
+			count++
+		}
+	}
+
+	tree := smt.NewWithDepth(h, int(depth))
+	tree.SetNodes(nodes, root, count)
+
+	return tree, crlNumber, nil
+}
+
+// ExportBinaryFile atomically writes a binary snapshot to the given path.
+// If the path ends with ".gz", the output is gzip-compressed.
+func ExportBinaryFile(tree *smt.SMT, crlNumber uint64, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+
+	f, err := os.CreateTemp(filepath.Dir(path), "snapshot-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create tmp: %w", err)
+	}
+	tmpPath := f.Name()
+
+	var w io.Writer = f
+	var gw *gzip.Writer
+	if strings.HasSuffix(path, ".gz") {
+		gw = gzip.NewWriter(f)
+		w = gw
+	}
+
+	if err := ExportBinary(tree, crlNumber, w); err != nil {
+		if gw != nil {
+			gw.Close()
+		}
+		f.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("export: %w", err)
+	}
+	if gw != nil {
+		if err := gw.Close(); err != nil {
+			f.Close()
+			os.Remove(tmpPath)
+			return fmt.Errorf("gzip close: %w", err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("close: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+// ImportBinaryFile reads a binary snapshot from the given path.
+// If the path ends with ".gz", the input is gzip-decompressed.
+func ImportBinaryFile(h smt.Hasher, path string) (*smt.SMT, uint64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer f.Close()
+
+	var r io.Reader = f
+	if strings.HasSuffix(path, ".gz") {
+		gr, err := gzip.NewReader(f)
+		if err != nil {
+			return nil, 0, fmt.Errorf("gzip reader: %w", err)
+		}
+		defer gr.Close()
+		r = gr
+	}
+
+	return ImportBinary(h, r)
+}
+
+// bigTo32Bytes converts a big.Int to a zero-padded 32-byte big-endian array.
+func bigTo32Bytes(n *big.Int) [32]byte {
+	var buf [32]byte
+	if n != nil && n.Sign() > 0 {
+		n.FillBytes(buf[:])
+	}
+	return buf
+}
+
+func writeByte(w io.Writer, b byte) error {
+	_, err := w.Write([]byte{b})
+	return err
+}

--- a/server/internal/snapshot/binary.go
+++ b/server/internal/snapshot/binary.go
@@ -121,6 +121,9 @@ func ImportBinary(h smt.Hasher, r io.Reader) (*smt.SMT, uint64, error) {
 			return nil, 0, fmt.Errorf("read node %d hash: %w", i, err)
 		}
 
+		if typeBuf[0] > 1 {
+			return nil, 0, fmt.Errorf("invalid node %d type: %d (expected 0=branch or 1=leaf)", i, typeBuf[0])
+		}
 		isLeaf := typeBuf[0] == 1
 		numChildren := 2
 		if isLeaf {

--- a/server/internal/snapshot/binary_test.go
+++ b/server/internal/snapshot/binary_test.go
@@ -1,0 +1,240 @@
+package snapshot
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moven0831/moica-revocation-smt/server/internal/smt"
+)
+
+func buildTestTree(t *testing.T) *smt.SMT {
+	t.Helper()
+	h := smt.NewPoseidonHasher()
+	tree := smt.New(h)
+
+	serials := []string{
+		"100048210DD2DF2E128096A9282B5EC5",
+		"200048210DD2DF2E128096A9282B5EC5",
+		"300048210DD2DF2E128096A9282B5EC5",
+	}
+	for _, s := range serials {
+		key, _ := new(big.Int).SetString(s, 16)
+		if err := tree.Add(key, big.NewInt(1)); err != nil {
+			t.Fatalf("add %s: %v", s, err)
+		}
+	}
+	return tree
+}
+
+func TestBinaryRoundTrip(t *testing.T) {
+	h := smt.NewPoseidonHasher()
+	tree := buildTestTree(t)
+
+	originalRoot := new(big.Int).Set(tree.Root)
+	originalCount := tree.Count
+	var crlNum uint64 = 42
+
+	// Export
+	var buf bytes.Buffer
+	if err := ExportBinary(tree, crlNum, &buf); err != nil {
+		t.Fatal("export:", err)
+	}
+
+	// Import
+	restored, gotCRL, err := ImportBinary(h, &buf)
+	if err != nil {
+		t.Fatal("import:", err)
+	}
+
+	// Verify metadata
+	if restored.Root.Cmp(originalRoot) != 0 {
+		t.Errorf("root mismatch: got %s, want %s", restored.Root.Text(16), originalRoot.Text(16))
+	}
+	if restored.Count != originalCount {
+		t.Errorf("count mismatch: got %d, want %d", restored.Count, originalCount)
+	}
+	if gotCRL != crlNum {
+		t.Errorf("crlNumber: got %d, want %d", gotCRL, crlNum)
+	}
+
+	// Verify membership proof
+	key, _ := new(big.Int).SetString("100048210DD2DF2E128096A9282B5EC5", 16)
+	proof := restored.CreateProof(key)
+	if !proof.Membership {
+		t.Fatal("membership proof failed on restored tree")
+	}
+	if !smt.VerifyProof(h, proof, smt.DefaultDepth) {
+		t.Fatal("proof verification failed on restored tree")
+	}
+
+	// Verify non-membership proof
+	nonMember, _ := new(big.Int).SetString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 16)
+	nonProof := restored.CreateProof(nonMember)
+	if nonProof.Membership {
+		t.Fatal("non-member should not be member")
+	}
+	if !smt.VerifyProof(h, nonProof, smt.DefaultDepth) {
+		t.Fatal("non-membership proof verification failed")
+	}
+}
+
+func TestBinaryEmptyTree(t *testing.T) {
+	h := smt.NewPoseidonHasher()
+	tree := smt.New(h)
+
+	var buf bytes.Buffer
+	if err := ExportBinary(tree, 0, &buf); err != nil {
+		t.Fatal("export empty:", err)
+	}
+
+	restored, _, err := ImportBinary(h, &buf)
+	if err != nil {
+		t.Fatal("import empty:", err)
+	}
+
+	if restored.Root.Sign() != 0 {
+		t.Error("empty tree root should be zero")
+	}
+	if restored.Count != 0 {
+		t.Error("empty tree count should be zero")
+	}
+}
+
+func TestBinaryCrossFormat(t *testing.T) {
+	h := smt.NewPoseidonHasher()
+	tree := buildTestTree(t)
+
+	// Export as JSON
+	var jsonBuf bytes.Buffer
+	if err := Export(tree, 99, &jsonBuf); err != nil {
+		t.Fatal("json export:", err)
+	}
+
+	// Import from JSON
+	jsonTree, _, err := Import(h, &jsonBuf)
+	if err != nil {
+		t.Fatal("json import:", err)
+	}
+
+	// Export as binary from the JSON-imported tree
+	var binBuf bytes.Buffer
+	if err := ExportBinary(jsonTree, 99, &binBuf); err != nil {
+		t.Fatal("binary export:", err)
+	}
+
+	// Import from binary
+	binTree, _, err := ImportBinary(h, &binBuf)
+	if err != nil {
+		t.Fatal("binary import:", err)
+	}
+
+	// Roots must match
+	if jsonTree.Root.Cmp(binTree.Root) != 0 {
+		t.Errorf("root mismatch: json=%s, binary=%s",
+			jsonTree.Root.Text(16), binTree.Root.Text(16))
+	}
+
+	// Proof from binary-imported tree must match
+	key, _ := new(big.Int).SetString("200048210DD2DF2E128096A9282B5EC5", 16)
+	jsonProof := jsonTree.CreateProof(key)
+	binProof := binTree.CreateProof(key)
+
+	if jsonProof.Membership != binProof.Membership {
+		t.Error("membership flag mismatch between formats")
+	}
+	if len(jsonProof.Siblings) != len(binProof.Siblings) {
+		t.Errorf("siblings length mismatch: json=%d, binary=%d",
+			len(jsonProof.Siblings), len(binProof.Siblings))
+	}
+}
+
+func TestBinaryTruncated(t *testing.T) {
+	h := smt.NewPoseidonHasher()
+	tree := buildTestTree(t)
+
+	var buf bytes.Buffer
+	if err := ExportBinary(tree, 0, &buf); err != nil {
+		t.Fatal("export:", err)
+	}
+
+	// Truncate to just the header + 1 byte (not enough for a full node)
+	truncated := buf.Bytes()[:BinaryHeader+1]
+	_, _, err := ImportBinary(h, bytes.NewReader(truncated))
+	if err == nil {
+		t.Fatal("expected error on truncated binary")
+	}
+}
+
+func TestBinaryInvalidMagic(t *testing.T) {
+	h := smt.NewPoseidonHasher()
+
+	var buf [BinaryHeader]byte
+	binary.BigEndian.PutUint16(buf[0:2], 0xDEAD) // wrong magic
+	binary.BigEndian.PutUint16(buf[2:4], BinaryVersion)
+
+	_, _, err := ImportBinary(h, bytes.NewReader(buf[:]))
+	if err == nil {
+		t.Fatal("expected error on invalid magic")
+	}
+}
+
+func TestBinaryUnknownVersion(t *testing.T) {
+	h := smt.NewPoseidonHasher()
+
+	var buf [BinaryHeader]byte
+	binary.BigEndian.PutUint16(buf[0:2], BinaryMagic)
+	binary.BigEndian.PutUint16(buf[2:4], 99) // unsupported version
+
+	_, _, err := ImportBinary(h, bytes.NewReader(buf[:]))
+	if err == nil {
+		t.Fatal("expected error on unknown version")
+	}
+}
+
+func TestBinaryFileRoundTrip(t *testing.T) {
+	h := smt.NewPoseidonHasher()
+	tree := buildTestTree(t)
+
+	dir := t.TempDir()
+
+	// Test uncompressed
+	rawPath := filepath.Join(dir, "test.bin")
+	if err := ExportBinaryFile(tree, 42, rawPath); err != nil {
+		t.Fatal("ExportBinaryFile:", err)
+	}
+	restored, crl, err := ImportBinaryFile(h, rawPath)
+	if err != nil {
+		t.Fatal("ImportBinaryFile:", err)
+	}
+	if restored.Root.Cmp(tree.Root) != 0 {
+		t.Error("root mismatch (uncompressed)")
+	}
+	if crl != 42 {
+		t.Errorf("crl: got %d, want 42", crl)
+	}
+
+	// Test gzip-compressed
+	gzPath := filepath.Join(dir, "test.bin.gz")
+	if err := ExportBinaryFile(tree, 42, gzPath); err != nil {
+		t.Fatal("ExportBinaryFile gz:", err)
+	}
+	restored2, _, err := ImportBinaryFile(h, gzPath)
+	if err != nil {
+		t.Fatal("ImportBinaryFile gz:", err)
+	}
+	if restored2.Root.Cmp(tree.Root) != 0 {
+		t.Error("root mismatch (compressed)")
+	}
+
+	// Verify no tmp files remain
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("stale temp file: %s", e.Name())
+		}
+	}
+}

--- a/server/wasm/benchmark.html
+++ b/server/wasm/benchmark.html
@@ -1,0 +1,272 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SMT WASM Benchmark</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
+  h1 { font-size: 1.4rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ddd; padding: 8px 12px; text-align: left; }
+  th { background: #f5f5f5; }
+  .metric-val { font-family: monospace; font-weight: bold; }
+  #status { padding: 1rem; background: #f0f0f0; border-radius: 4px; margin: 1rem 0; white-space: pre-wrap; font-family: monospace; font-size: 0.85rem; max-height: 300px; overflow-y: auto; }
+  .error { color: #c00; }
+  .pass { color: #080; }
+  input { padding: 4px 8px; font-family: monospace; width: 320px; }
+  button { padding: 6px 16px; cursor: pointer; }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+</style>
+</head>
+<body>
+
+<h1>MOICA SMT WASM Benchmark</h1>
+
+<div>
+  <label>Snapshot URL (gzipped binary): <br>
+    <input id="snapshotUrl" type="text" value="tree-snapshot.bin.gz" placeholder="URL or local path to .bin.gz snapshot">
+  </label>
+  <div style="font-size:0.8rem;color:#666;margin-top:2px;">
+    Use <code>make benchmark</code> to convert the local JSON snapshot and serve this page.
+  </div>
+</div>
+<div style="margin-top: 8px;">
+  <label>Test serial number (hex): <br>
+    <input id="testKey" type="text" value="100048210DD2DF2E128096A9282B5EC5" placeholder="hex serial number">
+  </label>
+</div>
+<div style="margin-top: 8px;">
+  <button id="runBtn" onclick="runBenchmark()" disabled>Loading WASM...</button>
+</div>
+
+<div id="status">Initializing...</div>
+
+<table id="results" style="display:none;">
+  <thead>
+    <tr><th>Metric</th><th>Value</th></tr>
+  </thead>
+  <tbody id="resultsBody"></tbody>
+</table>
+
+<div id="proofOutput" style="display:none; margin-top:1rem;">
+  <h3>Proof</h3>
+  <pre id="proofJSON" style="background:#f5f5f5; padding:1rem; overflow-x:auto; font-size:0.8rem; max-height:300px; overflow-y:auto;"></pre>
+</div>
+
+<script src="wasm_exec.js"></script>
+<script>
+const CHUNK_SIZE = 10000;
+const BINARY_HEADER_SIZE = 52;
+const BRANCH_NODE_SIZE = 97; // 1 + 32 + 32 + 32
+const LEAF_NODE_SIZE = 129;  // 1 + 32 + 32 + 32 + 32
+
+const statusEl = document.getElementById('status');
+const runBtn = document.getElementById('runBtn');
+
+function log(msg) {
+  statusEl.textContent += msg + '\n';
+  statusEl.scrollTop = statusEl.scrollHeight;
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+  return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+}
+
+function formatMs(ms) {
+  if (ms < 1000) return ms.toFixed(0) + ' ms';
+  return (ms / 1000).toFixed(2) + ' s';
+}
+
+function addResult(metric, value) {
+  const tbody = document.getElementById('resultsBody');
+  const tr = document.createElement('tr');
+  tr.innerHTML = `<td>${metric}</td><td class="metric-val">${value}</td>`;
+  tbody.appendChild(tr);
+  document.getElementById('results').style.display = '';
+}
+
+// Check for DecompressionStream support
+if (!('DecompressionStream' in window)) {
+  log('ERROR: DecompressionStream API not available in this browser.');
+  log('Required: Chrome 80+, Firefox 113+, Safari 16.4+');
+  statusEl.classList.add('error');
+} else {
+  // Load WASM
+  const go = new Go();
+  const wasmFetchStart = performance.now();
+  WebAssembly.instantiateStreaming(fetch('smt.wasm'), go.importObject).then(result => {
+    const wasmLoadTime = performance.now() - wasmFetchStart;
+    go.run(result.instance);
+    log(`WASM loaded in ${formatMs(wasmLoadTime)}`);
+    runBtn.textContent = 'Run Benchmark';
+    runBtn.disabled = false;
+    addResult('WASM binary size', formatBytes(result.module ? 'N/A' : 'N/A'));
+  }).catch(err => {
+    log('WASM load error: ' + err.message);
+    statusEl.classList.add('error');
+  });
+
+  // Also fetch the WASM size via HEAD
+  fetch('smt.wasm', { method: 'HEAD' }).then(r => {
+    const size = r.headers.get('content-length');
+    if (size) addResult('WASM binary size', formatBytes(parseInt(size)));
+  }).catch(() => {});
+}
+
+async function runBenchmark() {
+  runBtn.disabled = true;
+  statusEl.textContent = '';
+  document.getElementById('resultsBody').innerHTML = '';
+  document.getElementById('proofOutput').style.display = 'none';
+
+  const url = document.getElementById('snapshotUrl').value;
+  const testKey = document.getElementById('testKey').value;
+
+  try {
+    // 1. Download
+    log('Downloading snapshot...');
+    const dlStart = performance.now();
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    const contentLength = response.headers.get('content-length');
+    if (contentLength) addResult('Snapshot download size', formatBytes(parseInt(contentLength)));
+
+    // 2. Decompress
+    log('Decompressing...');
+    const decompStart = performance.now();
+    const dlTime = decompStart - dlStart;
+    addResult('Download time', formatMs(dlTime));
+
+    const ds = new DecompressionStream('gzip');
+    const decompressedStream = response.body.pipeThrough(ds);
+    const decompressedBlob = await new Response(decompressedStream).arrayBuffer();
+    const decompressedBytes = new Uint8Array(decompressedBlob);
+    const decompTime = performance.now() - decompStart;
+    addResult('Decompressed size', formatBytes(decompressedBytes.length));
+    addResult('Decompress time', formatMs(decompTime));
+    log(`Decompressed: ${formatBytes(decompressedBytes.length)} in ${formatMs(decompTime)}`);
+
+    // 3. Parse header
+    const view = new DataView(decompressedBytes.buffer);
+    const magic = view.getUint16(0);
+    if (magic !== 0x534D) throw new Error(`Invalid magic: 0x${magic.toString(16)}`);
+    const version = view.getUint16(2);
+    if (version !== 1) throw new Error(`Unsupported version: ${version}`);
+    const nodeCount = view.getUint32(4);
+    const rootHash = Array.from(decompressedBytes.slice(8, 40)).map(b => b.toString(16).padStart(2, '0')).join('');
+    const depth = view.getUint32(40);
+    const crlNumber = Number(view.getBigUint64(44));
+
+    log(`Header: ${nodeCount} nodes, depth=${depth}, CRL#${crlNumber}`);
+    addResult('Node count', nodeCount.toLocaleString());
+    addResult('Tree depth', depth);
+
+    // 4. Initialize tree
+    log('Initializing WASM tree...');
+    smtInitTree(nodeCount, depth);
+
+    // 5. Stream nodes in chunks
+    log('Loading nodes into WASM...');
+    const loadStart = performance.now();
+    let offset = BINARY_HEADER_SIZE;
+    let totalParsed = 0;
+    let chunkNum = 0;
+
+    while (offset < decompressedBytes.length) {
+      // Determine chunk end: read up to CHUNK_SIZE nodes
+      let chunkEnd = offset;
+      let nodesInChunk = 0;
+      while (nodesInChunk < CHUNK_SIZE && chunkEnd < decompressedBytes.length) {
+        const isLeaf = decompressedBytes[chunkEnd] === 1;
+        const nodeSize = isLeaf ? LEAF_NODE_SIZE : BRANCH_NODE_SIZE;
+        if (chunkEnd + nodeSize > decompressedBytes.length) break;
+        chunkEnd += nodeSize;
+        nodesInChunk++;
+      }
+
+      if (nodesInChunk === 0) break;
+
+      const chunk = decompressedBytes.slice(offset, chunkEnd);
+      const parsed = smtAddNodeChunk(chunk);
+      totalParsed += parsed;
+      offset = chunkEnd;
+      chunkNum++;
+
+      if (chunkNum % 10 === 0) {
+        log(`  Loaded ${totalParsed.toLocaleString()} / ${nodeCount.toLocaleString()} nodes`);
+      }
+    }
+
+    const loadTime = performance.now() - loadStart;
+    log(`Loaded ${totalParsed.toLocaleString()} nodes in ${formatMs(loadTime)}`);
+    addResult('Tree load time', formatMs(loadTime));
+
+    // Count leaves for finalize
+    // We know from the binary format that leaves have type=1
+    // totalParsed is total nodes; we need leaf count
+    // Re-scan to count leaves (fast, just check type bytes)
+    let leafCount = 0;
+    let scanOffset = BINARY_HEADER_SIZE;
+    while (scanOffset < decompressedBytes.length) {
+      const isLeaf = decompressedBytes[scanOffset] === 1;
+      if (isLeaf) leafCount++;
+      scanOffset += isLeaf ? LEAF_NODE_SIZE : BRANCH_NODE_SIZE;
+    }
+
+    // 6. Finalize
+    smtFinalize(rootHash, leafCount);
+    log(`Finalized: root=${rootHash.slice(0,16)}..., count=${leafCount}`);
+    addResult('Leaf count (entries)', leafCount.toLocaleString());
+
+    // 7. Memory stats
+    const memJSON = smtGetMemStats();
+    const mem = JSON.parse(memJSON);
+    addResult('WASM heap in use', formatBytes(mem.heapInuse));
+    addResult('WASM heap alloc', formatBytes(mem.heapAlloc));
+    addResult('WASM sys memory', formatBytes(mem.sys));
+    addResult('GC cycles', mem.numGC);
+    log(`Memory: heapInuse=${formatBytes(mem.heapInuse)}, sys=${formatBytes(mem.sys)}`);
+
+    // 8. Generate proof
+    log(`Generating proof for ${testKey}...`);
+    const proofStart = performance.now();
+    const proofJSON = smtCreateProof(testKey);
+    const proofTime = performance.now() - proofStart;
+    addResult('Proof generation time', formatMs(proofTime));
+    log(`Proof generated in ${formatMs(proofTime)}`);
+
+    const proof = JSON.parse(proofJSON);
+    addResult('Proof type', proof.membership ? 'Membership' : 'Non-membership');
+    addResult('Siblings count', proof.siblings.length);
+
+    // 9. Verify proof
+    const verifyStart = performance.now();
+    const valid = smtVerifyProof(proofJSON);
+    const verifyTime = performance.now() - verifyStart;
+    addResult('Proof verification time', formatMs(verifyTime));
+    addResult('Proof valid', valid ? 'YES' : 'NO');
+    log(`Verification: ${valid ? 'VALID' : 'INVALID'} in ${formatMs(verifyTime)}`);
+
+    // 10. Total time
+    const totalTime = performance.now() - dlStart;
+    addResult('TOTAL end-to-end time', formatMs(totalTime));
+    log(`\nDONE. Total: ${formatMs(totalTime)}`);
+    statusEl.classList.add(valid ? 'pass' : 'error');
+
+    // Show proof
+    document.getElementById('proofJSON').textContent = JSON.stringify(proof, null, 2);
+    document.getElementById('proofOutput').style.display = '';
+
+  } catch (err) {
+    log(`\nERROR: ${err.message}`);
+    statusEl.classList.add('error');
+  } finally {
+    runBtn.disabled = false;
+  }
+}
+</script>
+</body>
+</html>

--- a/server/wasm/main.go
+++ b/server/wasm/main.go
@@ -53,6 +53,9 @@ func addNodeChunk(_ js.Value, args []js.Value) any {
 	if len(args) < 1 {
 		return jsError("addNodeChunk requires (uint8Array)")
 	}
+	if nodes == nil {
+		return jsError("call smtInitTree before smtAddNodeChunk")
+	}
 
 	jsArr := args[0]
 	length := jsArr.Get("length").Int()
@@ -103,6 +106,9 @@ func finalize(_ js.Value, args []js.Value) any {
 	if len(args) < 2 {
 		return jsError("finalize requires (rootHex, count)")
 	}
+	if tree == nil {
+		return jsError("call smtInitTree before smtFinalize")
+	}
 
 	rootHex := args[0].String()
 	count := args[1].Int()
@@ -123,6 +129,9 @@ func finalize(_ js.Value, args []js.Value) any {
 func createProof(_ js.Value, args []js.Value) any {
 	if len(args) < 1 {
 		return jsError("createProof requires (keyHex)")
+	}
+	if tree == nil {
+		return jsError("tree not initialized — call smtInitTree and smtFinalize first")
 	}
 
 	keyHex := args[0].String()
@@ -145,6 +154,9 @@ func createProof(_ js.Value, args []js.Value) any {
 func verifyProof(_ js.Value, args []js.Value) any {
 	if len(args) < 1 {
 		return jsError("verifyProof requires (proofJSON)")
+	}
+	if tree == nil {
+		return jsError("tree not initialized — call smtInitTree and smtFinalize first")
 	}
 
 	proofJSON := args[0].String()

--- a/server/wasm/main.go
+++ b/server/wasm/main.go
@@ -1,0 +1,248 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"runtime"
+	"syscall/js"
+
+	"github.com/moven0831/moica-revocation-smt/server/internal/smt"
+)
+
+var (
+	hasher smt.Hasher
+	tree   *smt.SMT
+	nodes  map[string]smt.ChildNodes
+)
+
+func main() {
+	hasher = smt.NewPoseidonHasher()
+
+	js.Global().Set("smtInitTree", js.FuncOf(initTree))
+	js.Global().Set("smtAddNodeChunk", js.FuncOf(addNodeChunk))
+	js.Global().Set("smtFinalize", js.FuncOf(finalize))
+	js.Global().Set("smtCreateProof", js.FuncOf(createProof))
+	js.Global().Set("smtVerifyProof", js.FuncOf(verifyProof))
+	js.Global().Set("smtGetMemStats", js.FuncOf(getMemStats))
+	js.Global().Set("smtReady", js.ValueOf(true))
+
+	// Block forever
+	select {}
+}
+
+// initTree(nodeCount, depth) — pre-allocates the node map.
+func initTree(_ js.Value, args []js.Value) any {
+	if len(args) < 2 {
+		return jsError("initTree requires (nodeCount, depth)")
+	}
+	nodeCount := args[0].Int()
+	depth := args[1].Int()
+
+	tree = smt.NewWithDepth(hasher, depth)
+	nodes = make(map[string]smt.ChildNodes, nodeCount)
+	return nil
+}
+
+// addNodeChunk(uint8Array) — receives a chunk of serialized binary nodes.
+// Each node: 1-byte type + 32-byte hash + children (branch: 2x32, leaf: 3x32).
+// Returns the number of nodes parsed from this chunk.
+func addNodeChunk(_ js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		return jsError("addNodeChunk requires (uint8Array)")
+	}
+
+	jsArr := args[0]
+	length := jsArr.Get("length").Int()
+	buf := make([]byte, length)
+	js.CopyBytesToGo(buf, jsArr)
+
+	parsed := 0
+	offset := 0
+
+	for offset < length {
+		if offset+33 > length {
+			break // not enough data for type + hash
+		}
+
+		isLeaf := buf[offset] == 1
+		offset++
+
+		var hashBuf [32]byte
+		copy(hashBuf[:], buf[offset:offset+32])
+		offset += 32
+
+		numChildren := 2
+		if isLeaf {
+			numChildren = 3
+		}
+
+		childrenSize := numChildren * 32
+		if offset+childrenSize > length {
+			break // not enough data for children
+		}
+
+		children := make(smt.ChildNodes, numChildren)
+		for j := 0; j < numChildren; j++ {
+			children[j] = new(big.Int).SetBytes(buf[offset : offset+32])
+			offset += 32
+		}
+
+		hashKey := new(big.Int).SetBytes(hashBuf[:]).Text(16)
+		nodes[hashKey] = children
+		parsed++
+	}
+
+	return parsed
+}
+
+// finalize(rootHex, count) — sets the root and count, making the tree ready for proofs.
+func finalize(_ js.Value, args []js.Value) any {
+	if len(args) < 2 {
+		return jsError("finalize requires (rootHex, count)")
+	}
+
+	rootHex := args[0].String()
+	count := args[1].Int()
+
+	root, ok := new(big.Int).SetString(rootHex, 16)
+	if !ok {
+		return jsError(fmt.Sprintf("invalid root hex: %s", rootHex))
+	}
+
+	tree.SetNodes(nodes, root, count)
+	// Allow GC of the temporary nodes map reference
+	nodes = nil
+
+	return nil
+}
+
+// createProof(keyHex) — generates a proof and returns it as JSON.
+func createProof(_ js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		return jsError("createProof requires (keyHex)")
+	}
+
+	keyHex := args[0].String()
+	key, ok := new(big.Int).SetString(keyHex, 16)
+	if !ok {
+		return jsError(fmt.Sprintf("invalid key hex: %s", keyHex))
+	}
+
+	proof := tree.CreateProof(key)
+	result := proofToJSON(proof)
+
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return jsError(fmt.Sprintf("marshal proof: %v", err))
+	}
+	return string(jsonBytes)
+}
+
+// verifyProof(proofJSON) — verifies a proof and returns a boolean.
+func verifyProof(_ js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		return jsError("verifyProof requires (proofJSON)")
+	}
+
+	proofJSON := args[0].String()
+	var jp jsonProof
+	if err := json.Unmarshal([]byte(proofJSON), &jp); err != nil {
+		return jsError(fmt.Sprintf("unmarshal proof: %v", err))
+	}
+
+	proof := jsonToProof(&jp)
+	return smt.VerifyProof(hasher, proof, tree.Depth)
+}
+
+// getMemStats() — returns Go runtime memory statistics as JSON.
+func getMemStats(_ js.Value, _ []js.Value) any {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	result := map[string]any{
+		"alloc":      m.Alloc,
+		"totalAlloc": m.TotalAlloc,
+		"sys":        m.Sys,
+		"heapInuse":  m.HeapInuse,
+		"heapAlloc":  m.HeapAlloc,
+		"numGC":      m.NumGC,
+	}
+
+	jsonBytes, _ := json.Marshal(result)
+	return string(jsonBytes)
+}
+
+func jsError(msg string) any {
+	return js.Global().Get("Error").New(msg)
+}
+
+// JSON proof serialization types
+type jsonProof struct {
+	Entry         []string `json:"entry"`
+	MatchingEntry []string `json:"matchingEntry,omitempty"`
+	Siblings      []string `json:"siblings"`
+	Root          string   `json:"root"`
+	Membership    bool     `json:"membership"`
+}
+
+func bigToHex(n *big.Int) string {
+	if n == nil || n.Sign() == 0 {
+		return "0"
+	}
+	return n.Text(16)
+}
+
+func hexToBig(s string) *big.Int {
+	n, _ := new(big.Int).SetString(s, 16)
+	if n == nil {
+		return new(big.Int)
+	}
+	return n
+}
+
+func proofToJSON(p *smt.MerkleProof) *jsonProof {
+	jp := &jsonProof{
+		Entry:      make([]string, len(p.Entry)),
+		Siblings:   make([]string, len(p.Siblings)),
+		Root:       bigToHex(p.Root),
+		Membership: p.Membership,
+	}
+	for i, v := range p.Entry {
+		jp.Entry[i] = bigToHex(v)
+	}
+	for i, v := range p.Siblings {
+		jp.Siblings[i] = bigToHex(v)
+	}
+	if p.MatchingEntry != nil {
+		jp.MatchingEntry = make([]string, len(p.MatchingEntry))
+		for i, v := range p.MatchingEntry {
+			jp.MatchingEntry[i] = bigToHex(v)
+		}
+	}
+	return jp
+}
+
+func jsonToProof(jp *jsonProof) *smt.MerkleProof {
+	p := &smt.MerkleProof{
+		Entry:      make([]*big.Int, len(jp.Entry)),
+		Siblings:   make([]*big.Int, len(jp.Siblings)),
+		Root:       hexToBig(jp.Root),
+		Membership: jp.Membership,
+	}
+	for i, s := range jp.Entry {
+		p.Entry[i] = hexToBig(s)
+	}
+	for i, s := range jp.Siblings {
+		p.Siblings[i] = hexToBig(s)
+	}
+	if jp.MatchingEntry != nil {
+		p.MatchingEntry = make([]*big.Int, len(jp.MatchingEntry))
+		for i, s := range jp.MatchingEntry {
+			p.MatchingEntry[i] = hexToBig(s)
+		}
+	}
+	return p
+}


### PR DESCRIPTION
## related issues
- #21 
- https://github.com/zkmopro/ZK-based-Human-Verification/issues/16

## Summary

- Add Go WASM module (`server/wasm/main.go`, ~3.3MB compiled) exposing `smtInitTree`, `smtAddNodeChunk`, `smtFinalize`, `smtCreateProof`, `smtVerifyProof` for in-browser SMT operations
- Add binary snapshot format (`server/internal/snapshot/binary.go`) with 52-byte header + packed nodes — ~7% smaller than JSON, designed for chunked streaming to WASM
- Add `--binary` and `--convert-binary` flags to `smtbuild` CLI, `RawNode`/`NodesRaw`/`SetNodes` methods to `smt.SMT`, and `build-wasm`/`build-binary`/`benchmark` Makefile targets
- Update CI: WASM build check in `ci.yml`, binary snapshot + WASM artifact publishing in `update-smt.yml` (smt.wasm, wasm_exec.js, .bin.gz, .bin)
- Document WASM API, binary format, client integration guide, release assets, performance benchmarks, and mobile integration path in README

## Test plan

- [x] `go test ./...` — all 43 tests pass
- [x] `GOOS=js GOARCH=wasm go build -o /dev/null ./wasm/` — WASM compiles successfully
- [ ] After merge: trigger `update-smt.yml` workflow and verify `snapshot-latest` release includes all 4 new assets (smt.wasm, wasm_exec.js, g2-tree-snapshot.bin.gz, g2-tree-snapshot.bin)
- [ ] Run `make benchmark` locally to verify end-to-end browser benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)